### PR TITLE
refactor: unify design system and navigation scripts

### DIFF
--- a/DESIGN_REFACTOR.md
+++ b/DESIGN_REFACTOR.md
@@ -1,0 +1,33 @@
+# Design Refactor Context
+
+This document captures the goals and guidelines for the ongoing visual and interaction overhaul of the site. It is based on the initial audit of the existing implementation.
+
+## 1. Establish unified design tokens
+- Introduce a dedicated `tokens.css` for colors, typography scale, spacing, radii, shadows, animation curves, and breakpoints.
+- Replace hard‑coded values across components with token variables for consistency and maintainability.
+
+## 2. Clarify typography and spacing hierarchy
+- Apply a coherent type scale and consistent spacing rhythm to all sections.
+- Adopt a shared container width and grid system to reinforce visual structure.
+
+## 3. Centralize interaction logic
+- Refactor the header and other interactive components for proper ARIA attributes and keyboard support.
+- Move scattered scripts into reusable modules (e.g., `scripts/main.ts`).
+
+## 4. Standardize motion and animation
+- Define easing curves and durations in tokens and reuse them across components.
+- Trigger animations via `IntersectionObserver` and honor `prefers-reduced-motion`.
+
+## 5. Unify responsive breakpoints
+- Declare standard breakpoints in `tokens.css` and reference them throughout stylesheets.
+- Ensure layouts remain legible on narrow screens with flex/grid adjustments.
+
+## 6. Improve accessibility
+- Provide descriptive `alt` text and ARIA labels.
+- Verify color contrast with automated tools and document accessibility guidelines.
+
+## 7. Optimize performance
+- Self-host fonts and enable `font-display: swap`.
+- Lazy‑load large images and adopt Astro's island architecture for heavy scripts.
+
+These principles serve as the reference for subsequent code refactors and component updates.

--- a/src/components/AboutSection.astro
+++ b/src/components/AboutSection.astro
@@ -145,20 +145,20 @@
   
   .philosophy-quote {
     position: relative;
-    padding: var(--spacing-xl);
-    border-left: 4px solid var(--accent-primary);
+    padding: var(--space-8);
+    border-left: 4px solid var(--color-accent);
     background: rgba(87, 81, 213, 0.05);
     border-radius: 0 12px 12px 0;
   }
   
   .philosophy-quote blockquote {
-    margin: 0 0 var(--spacing-sm) 0;
+    margin: 0 0 var(--space-3) 0;
     line-height: 1.6;
-    color: var(--text-primary);
+    color: var(--color-primary);
   }
   
   .about-stats {
-    margin: var(--spacing-2xl) 0;
+    margin: var(--space-12) 0;
   }
   
   .stat-item {
@@ -168,13 +168,13 @@
   .stat-number {
     font-size: var(--text-5xl);
     line-height: 1;
-    margin-bottom: var(--spacing-xs);
+    margin-bottom: var(--space-2);
   }
   
   .stat-label {
     font-size: var(--text-lg);
-    margin-bottom: var(--spacing-xs);
-    color: var(--text-primary);
+    margin-bottom: var(--space-2);
+    color: var(--color-primary);
   }
   
   /* 视觉元素样式 */
@@ -208,7 +208,7 @@
   .circle-outer {
     width: 200px;
     height: 200px;
-    border: 3px solid var(--accent-primary);
+    border: 3px solid var(--color-accent);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -221,7 +221,7 @@
   .circle-inner {
     width: 120px;
     height: 120px;
-    border: 2px solid var(--text-primary);
+    border: 2px solid var(--color-primary);
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -232,7 +232,7 @@
   .tao-text {
     font-size: var(--text-6xl);
     font-weight: 900;
-    color: var(--accent-primary);
+    color: var(--color-accent);
   }
   
   /* 装饰性文字 */
@@ -335,7 +335,7 @@
   }
   
   .culture-icon {
-    color: var(--accent-primary);
+    color: var(--color-accent);
     display: block;
   }
   
@@ -343,7 +343,7 @@
   @media (max-width: 768px) {
     .about-content {
       grid-template-columns: 1fr;
-      gap: var(--spacing-3xl);
+      gap: var(--space-16);
     }
     
     .about-visual {
@@ -372,7 +372,7 @@
     
     .culture-grid {
       grid-template-columns: 1fr;
-      gap: var(--spacing-lg);
+      gap: var(--space-6);
     }
   }
   

--- a/src/components/AppleHeroSection.astro
+++ b/src/components/AppleHeroSection.astro
@@ -97,13 +97,13 @@ import { COMPANY_NAME, TRANSLATIONS, KPI_DATA } from '../consts';
     justify-content: center;
     position: relative;
     overflow: hidden;
-    background: linear-gradient(135deg, #FFFFFF 0%, #F5F5F7 100%);
+    background: linear-gradient(135deg, var(--color-background) 0%, var(--color-surface) 100%);
   }
   
   .hero-container {
     max-width: 1200px;
     width: 100%;
-    padding: 0 40px;
+    padding: 0 var(--space-10);
     text-align: center;
     position: relative;
     z-index: 10;
@@ -111,20 +111,20 @@ import { COMPANY_NAME, TRANSLATIONS, KPI_DATA } from '../consts';
   
   /* Hero Content */
   .hero-eyebrow {
-    margin-bottom: 24px;
+    margin-bottom: var(--space-6);
     opacity: 0;
-    animation: fadeInUp 0.8s ease-out 0.2s forwards;
+    animation: fadeInUp 0.8s var(--ease-out) 0.2s forwards;
   }
   
   .eyebrow-text {
     display: inline-block;
-    font-size: 18px;
+    font-size: var(--text-xl);
     font-weight: 600;
-    color: #007AFF;
+    color: var(--color-accent);
     letter-spacing: 0.02em;
-    padding: 8px 16px;
+    padding: var(--space-2) var(--space-4);
     background: rgba(0, 122, 255, 0.1);
-    border-radius: 20px;
+    border-radius: var(--radius-2xl);
     backdrop-filter: blur(20px);
   }
   
@@ -133,69 +133,69 @@ import { COMPANY_NAME, TRANSLATIONS, KPI_DATA } from '../consts';
     font-weight: 700;
     line-height: 1.1;
     letter-spacing: -0.02em;
-    color: #1D1D1F;
-    margin-bottom: 32px;
+    color: var(--color-primary);
+    margin-bottom: var(--space-8);
     opacity: 0;
-    animation: fadeInUp 0.8s ease-out 0.4s forwards;
+    animation: fadeInUp 0.8s var(--ease-out) 0.4s forwards;
   }
   
   .hero-description {
     font-size: clamp(18px, 2.5vw, 24px);
     font-weight: 400;
     line-height: 1.5;
-    color: #86868B;
-    margin-bottom: 48px;
+    color: var(--color-secondary);
+    margin-bottom: var(--space-12);
     max-width: 800px;
     margin-left: auto;
     margin-right: auto;
     opacity: 0;
-    animation: fadeInUp 0.8s ease-out 0.6s forwards;
+    animation: fadeInUp 0.8s var(--ease-out) 0.6s forwards;
   }
   
   /* Hero Actions */
   .hero-actions {
     display: flex;
-    gap: 24px;
+    gap: var(--space-6);
     justify-content: center;
-    margin-bottom: 80px;
+    margin-bottom: var(--space-20);
     opacity: 0;
-    animation: fadeInUp 0.8s ease-out 0.8s forwards;
+    animation: fadeInUp 0.8s var(--ease-out) 0.8s forwards;
   }
   
   .btn-primary,
   .btn-secondary {
-    padding: 16px 32px;
-    border-radius: 50px;
-    font-size: 18px;
+    padding: var(--space-4) var(--space-8);
+    border-radius: var(--radius-full);
+    font-size: var(--text-xl);
     font-weight: 600;
     text-decoration: none;
     cursor: pointer;
     border: none;
-    transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    transition: all 0.3s var(--ease-out);
     min-width: 180px;
   }
   
   .btn-primary {
-    background: #1D1D1F;
-    color: #FFFFFF;
+    background: var(--color-primary);
+    color: var(--color-background);
     box-shadow: 0 4px 16px rgba(29, 29, 31, 0.2);
   }
   
   .btn-primary:hover {
-    background: #007AFF;
+    background: var(--color-accent);
     transform: translateY(-2px);
     box-shadow: 0 8px 24px rgba(0, 122, 255, 0.3);
   }
   
   .btn-secondary {
     background: transparent;
-    color: #007AFF;
-    border: 2px solid #007AFF;
+    color: var(--color-accent);
+    border: 2px solid var(--color-accent);
   }
   
   .btn-secondary:hover {
-    background: #007AFF;
-    color: #FFFFFF;
+    background: var(--color-accent);
+    color: var(--color-background);
     transform: translateY(-2px);
   }
   
@@ -203,13 +203,13 @@ import { COMPANY_NAME, TRANSLATIONS, KPI_DATA } from '../consts';
   .kpi-showcase {
     margin-bottom: 60px;
     opacity: 0;
-    animation: fadeInUp 0.8s ease-out 1s forwards;
+    animation: fadeInUp 0.8s var(--ease-out) 1s forwards;
   }
   
   .kpi-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 40px;
+    gap: var(--space-10);
     max-width: 900px;
     margin: 0 auto;
   }
@@ -221,18 +221,18 @@ import { COMPANY_NAME, TRANSLATIONS, KPI_DATA } from '../consts';
   .kpi-value {
     font-size: clamp(36px, 5vw, 48px);
     font-weight: 700;
-    color: #1D1D1F;
-    margin-bottom: 8px;
+    color: var(--color-primary);
+    margin-bottom: var(--space-2);
     display: flex;
     align-items: baseline;
     justify-content: center;
-    gap: 4px;
+    gap: var(--space-1);
   }
   
   .kpi-unit,
   .kpi-prefix {
     font-size: 0.6em;
-    color: #007AFF;
+    color: var(--color-accent);
   }
   
   .animated-number {
@@ -240,31 +240,31 @@ import { COMPANY_NAME, TRANSLATIONS, KPI_DATA } from '../consts';
   }
   
   .kpi-label {
-    font-size: 16px;
+    font-size: var(--text-lg);
     font-weight: 500;
-    color: #86868B;
+    color: var(--color-secondary);
     letter-spacing: 0.01em;
   }
   
   /* Scroll Indicator */
   .scroll-indicator {
     position: absolute;
-    bottom: 40px;
+    bottom: var(--space-10);
     left: 50%;
     transform: translateX(-50%);
     text-align: center;
     opacity: 0;
-    animation: fadeIn 1s ease-out 1.5s forwards;
+    animation: fadeIn 1s var(--ease-out) 1.5s forwards;
   }
   
   .scroll-text {
-    font-size: 14px;
-    color: #86868B;
+    font-size: var(--text-base);
+    color: var(--color-secondary);
     margin-bottom: 12px;
   }
   
   .scroll-arrow {
-    color: #86868B;
+    color: var(--color-secondary);
     animation: bounce 2s infinite;
   }
   
@@ -289,7 +289,7 @@ import { COMPANY_NAME, TRANSLATIONS, KPI_DATA } from '../consts';
   .gradient-orb-1 {
     width: 400px;
     height: 400px;
-    background: linear-gradient(135deg, #007AFF, #00D4FF);
+    background: linear-gradient(135deg, var(--color-accent), var(--color-accent-secondary));
     top: 10%;
     right: 10%;
     animation-delay: 0s;

--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -169,12 +169,12 @@
   }
   
   .section-number {
-    margin-bottom: var(--spacing-xl);
+    margin-bottom: var(--space-8);
   }
   
   .section-number .accent-number {
     display: block;
-    margin-bottom: var(--spacing-sm);
+    margin-bottom: var(--space-3);
   }
   
   .section-description {
@@ -190,14 +190,14 @@
   }
   
   .contact-methods {
-    margin-bottom: var(--spacing-xl);
+    margin-bottom: var(--space-8);
   }
   
   .contact-method {
     display: flex;
     align-items: flex-start;
-    gap: var(--spacing-lg);
-    padding: var(--spacing-lg) 0;
+    gap: var(--space-6);
+    padding: var(--space-6) 0;
     border-bottom: 1px solid rgba(22, 22, 21, 0.05);
   }
   
@@ -213,7 +213,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--accent-primary);
+    color: var(--color-accent);
     flex-shrink: 0;
   }
   
@@ -222,17 +222,17 @@
   }
   
   .method-content h4 {
-    margin-bottom: var(--spacing-xs);
-    color: var(--text-primary);
+    margin-bottom: var(--space-2);
+    color: var(--color-primary);
   }
   
   .contact-link {
-    color: var(--accent-primary);
+    color: var(--color-accent);
     text-decoration: none;
     font-weight: 600;
     font-size: var(--text-lg);
     display: block;
-    margin: var(--spacing-sm) 0;
+    margin: var(--space-3) 0;
     transition: opacity 0.3s ease;
   }
   
@@ -241,11 +241,11 @@
   }
   
   .contact-text {
-    color: var(--text-primary);
+    color: var(--color-primary);
     font-weight: 600;
     font-size: var(--text-lg);
     display: block;
-    margin: var(--spacing-sm) 0;
+    margin: var(--space-3) 0;
   }
   
   /* 办公地址样式 */
@@ -254,7 +254,7 @@
   }
   
   .address-info p {
-    margin-bottom: var(--spacing-sm);
+    margin-bottom: var(--space-3);
     line-height: 1.6;
   }
   
@@ -264,27 +264,27 @@
   }
   
   .form-group {
-    margin-bottom: var(--spacing-lg);
+    margin-bottom: var(--space-6);
   }
   
   .form-label {
     display: block;
-    margin-bottom: var(--spacing-sm);
+    margin-bottom: var(--space-3);
     font-weight: 600;
-    color: var(--text-primary);
+    color: var(--color-primary);
   }
   
   .form-input,
   .form-select,
   .form-textarea {
     width: 100%;
-    padding: var(--spacing-md) var(--spacing-lg);
+    padding: var(--space-4) var(--space-6);
     border: 2px solid rgba(22, 22, 21, 0.1);
     border-radius: 12px;
     font-size: var(--text-base);
     font-family: inherit;
     background: var(--bg-primary);
-    color: var(--text-primary);
+    color: var(--color-primary);
     transition: all 0.3s ease;
   }
   
@@ -292,13 +292,13 @@
   .form-select:focus,
   .form-textarea:focus {
     outline: none;
-    border-color: var(--accent-primary);
+    border-color: var(--color-accent);
     box-shadow: 0 0 0 3px rgba(87, 81, 213, 0.1);
   }
   
   .form-input::placeholder,
   .form-textarea::placeholder {
-    color: var(--text-secondary);
+    color: var(--color-secondary);
     opacity: 0.7;
   }
   
@@ -315,7 +315,7 @@
   .form-submit {
     width: 100%;
     justify-content: center;
-    padding: var(--spacing-lg) var(--spacing-2xl);
+    padding: var(--space-6) var(--space-12);
     font-size: var(--text-lg);
     font-weight: 600;
   }
@@ -329,18 +329,18 @@
   @media (max-width: 768px) {
     .contact-content {
       grid-template-columns: 1fr;
-      gap: var(--spacing-3xl);
+      gap: var(--space-16);
     }
     
     .form-row {
       grid-template-columns: 1fr;
-      gap: var(--spacing-md);
+      gap: var(--space-4);
     }
     
     .contact-method {
       flex-direction: column;
       text-align: center;
-      gap: var(--spacing-md);
+      gap: var(--space-4);
     }
     
     .method-icon {
@@ -352,11 +352,11 @@
     .form-input,
     .form-select,
     .form-textarea {
-      padding: var(--spacing-sm) var(--spacing-md);
+      padding: var(--space-3) var(--space-4);
     }
     
     .form-submit {
-      padding: var(--spacing-md) var(--spacing-xl);
+      padding: var(--space-4) var(--space-8);
       font-size: var(--text-base);
     }
   }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -136,13 +136,13 @@ const today = new Date();
       linear-gradient(135deg, rgba(22, 22, 21, 0.02) 0%, rgba(87, 81, 213, 0.03) 100%),
       radial-gradient(circle at 30% 70%, rgba(87, 81, 213, 0.05) 0%, transparent 50%);
     border-top: 1px solid rgba(22, 22, 21, 0.1);
-    padding: var(--spacing-5xl) 0 var(--spacing-3xl);
+    padding: var(--space-24) 0 var(--space-16);
     position: relative;
     overflow: hidden;
   }
   
   .footer-content {
-    margin-bottom: var(--spacing-4xl);
+    margin-bottom: var(--space-20);
   }
   
   /* 品牌信息 */
@@ -153,16 +153,16 @@ const today = new Date();
   .brand-logo {
     display: flex;
     align-items: center;
-    gap: var(--spacing-md);
-    margin-bottom: var(--spacing-lg);
+    gap: var(--space-4);
+    margin-bottom: var(--space-6);
   }
   
   .logo-symbol {
     font-size: var(--text-lg);
     font-weight: 700;
-    color: var(--accent-primary);
-    padding: var(--spacing-sm) var(--spacing-md);
-    border: 2px solid var(--accent-primary);
+    color: var(--color-accent);
+    padding: var(--space-3) var(--space-4);
+    border: 2px solid var(--color-accent);
     border-radius: 6px;
     line-height: 1;
   }
@@ -170,12 +170,12 @@ const today = new Date();
   .brand-info {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xs);
+    gap: var(--space-2);
   }
   
   .brand-name {
     font-size: var(--text-lg);
-    color: var(--text-primary);
+    color: var(--color-primary);
     line-height: 1;
   }
   
@@ -186,21 +186,21 @@ const today = new Date();
   
   .brand-description {
     line-height: 1.7;
-    margin-bottom: var(--spacing-lg);
+    margin-bottom: var(--space-6);
   }
   
   .contact-info {
-    margin-top: var(--spacing-lg);
+    margin-top: var(--space-6);
   }
   
   .contact-item {
     display: flex;
     align-items: center;
-    gap: var(--spacing-sm);
+    gap: var(--space-3);
   }
   
   .contact-link {
-    color: var(--accent-primary);
+    color: var(--color-accent);
     text-decoration: none;
     font-weight: 500;
     transition: opacity 0.3s ease;
@@ -217,8 +217,8 @@ const today = new Date();
   }
   
   .section-title {
-    color: var(--text-primary);
-    margin-bottom: var(--spacing-lg);
+    color: var(--color-primary);
+    margin-bottom: var(--space-6);
   }
   
   .footer-links {
@@ -228,11 +228,11 @@ const today = new Date();
   }
   
   .footer-links li {
-    margin-bottom: var(--spacing-sm);
+    margin-bottom: var(--space-3);
   }
   
   .footer-link {
-    color: var(--text-primary);
+    color: var(--color-primary);
     text-decoration: none;
     opacity: 0.8;
     transition: all 0.3s ease;
@@ -240,7 +240,7 @@ const today = new Date();
   }
   
   .footer-link:hover {
-    color: var(--accent-primary);
+    color: var(--color-accent);
     opacity: 1;
     transform: translateX(4px);
   }
@@ -249,13 +249,13 @@ const today = new Date();
   .contact-methods {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-md);
+    gap: var(--space-4);
   }
   
   .contact-method {
     display: flex;
     align-items: flex-start;
-    gap: var(--spacing-md);
+    gap: var(--space-4);
   }
   
   .method-icon {
@@ -273,11 +273,11 @@ const today = new Date();
   .method-info {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-xs);
+    gap: var(--space-2);
   }
   
   .contact-text {
-    color: var(--text-secondary);
+    color: var(--color-secondary);
   }
   
   /* 分割线 */
@@ -301,7 +301,7 @@ const today = new Date();
   }
   
   .philosophy-quote blockquote {
-    margin: 0 0 var(--spacing-xs) 0;
+    margin: 0 0 var(--space-2) 0;
     font-size: var(--text-lg);
     line-height: 1.4;
   }
@@ -344,29 +344,29 @@ const today = new Date();
   @media (max-width: 1024px) {
     .footer-content {
       grid-template-columns: repeat(2, 1fr);
-      gap: var(--spacing-2xl);
+      gap: var(--space-12);
     }
     
     .footer-brand {
       grid-column: span 2;
-      margin-bottom: var(--spacing-xl);
+      margin-bottom: var(--space-8);
     }
   }
   
   @media (max-width: 768px) {
     .footer-content {
       grid-template-columns: 1fr;
-      gap: var(--spacing-2xl);
+      gap: var(--space-12);
     }
     
     .footer-brand {
       grid-column: span 1;
-      margin-bottom: var(--spacing-lg);
+      margin-bottom: var(--space-6);
     }
     
     .footer-bottom-content {
       flex-direction: column;
-      gap: var(--spacing-xl);
+      gap: var(--space-8);
       text-align: center;
     }
     
@@ -378,13 +378,13 @@ const today = new Date();
     .brand-logo {
       flex-direction: column;
       text-align: center;
-      gap: var(--spacing-sm);
+      gap: var(--space-3);
     }
   }
   
   @media (max-width: 480px) {
     .site-footer {
-      padding: var(--spacing-3xl) 0 var(--spacing-2xl);
+      padding: var(--space-16) 0 var(--space-12);
     }
     
     .brand-info {
@@ -393,13 +393,13 @@ const today = new Date();
     
     .logo-symbol {
       font-size: var(--text-base);
-      padding: var(--spacing-xs) var(--spacing-sm);
+      padding: var(--space-2) var(--space-3);
     }
     
     .contact-method {
       flex-direction: column;
       text-align: center;
-      gap: var(--spacing-sm);
+      gap: var(--space-3);
     }
   }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -40,7 +40,7 @@ import LanguageSelector from './LanguageSelector.astro';
     </div>
     
     <!-- Mobile Menu Button -->
-    <button class="mobile-menu-btn" id="mobileMenuBtn" aria-label="Menu">
+    <button class="mobile-menu-btn" id="mobileMenuBtn" aria-label="Menu" aria-controls="mobileMenu" aria-expanded="false">
       <span class="menu-line"></span>
       <span class="menu-line"></span>
     </button>
@@ -98,8 +98,8 @@ import LanguageSelector from './LanguageSelector.astro';
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 40px;
-    height: 64px;
+    padding: 0 var(--space-10);
+    height: var(--space-16);
   }
   
   /* Brand */
@@ -114,9 +114,9 @@ import LanguageSelector from './LanguageSelector.astro';
   }
   
   .logo-text {
-    font-size: 20px;
+    font-size: var(--text-2xl);
     font-weight: 700;
-    color: #1D1D1F;
+    color: var(--color-primary);
     letter-spacing: -0.01em;
   }
   
@@ -124,15 +124,15 @@ import LanguageSelector from './LanguageSelector.astro';
   .nav-menu {
     display: flex;
     align-items: center;
-    gap: 40px;
+    gap: var(--space-10);
   }
   
   .nav-link {
-    font-size: 16px;
+    font-size: var(--text-lg);
     font-weight: 500;
-    color: #1D1D1F;
+    color: var(--color-primary);
     text-decoration: none;
-    padding: 8px 0;
+    padding: var(--space-2) 0;
     position: relative;
     transition: all 0.2s ease;
   }
@@ -144,7 +144,7 @@ import LanguageSelector from './LanguageSelector.astro';
     left: 0;
     right: 0;
     height: 2px;
-    background: #007AFF;
+    background: var(--color-accent);
     transform: scaleX(0);
     transform-origin: center;
     transition: transform 0.2s ease;
@@ -155,29 +155,29 @@ import LanguageSelector from './LanguageSelector.astro';
   }
   
   .nav-link:hover {
-    color: #007AFF;
+    color: var(--color-accent);
   }
   
   /* Right Actions */
   .nav-actions {
     display: flex;
     align-items: center;
-    gap: 20px;
+    gap: var(--space-5);
   }
   
   .nav-cta {
-    background: #1D1D1F;
-    color: #FFFFFF;
-    padding: 10px 20px;
-    border-radius: 20px;
-    font-size: 14px;
+    background: var(--color-primary);
+    color: var(--color-background);
+    padding: var(--space-3) var(--space-5);
+    border-radius: var(--space-5);
+    font-size: var(--text-base);
     font-weight: 600;
     text-decoration: none;
     transition: all 0.2s ease;
   }
   
   .nav-cta:hover {
-    background: #007AFF;
+    background: var(--color-accent);
     transform: translateY(-1px);
   }
   
@@ -187,8 +187,8 @@ import LanguageSelector from './LanguageSelector.astro';
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    width: 32px;
-    height: 32px;
+    width: var(--space-8);
+    height: var(--space-8);
     background: none;
     border: none;
     cursor: pointer;
@@ -197,9 +197,9 @@ import LanguageSelector from './LanguageSelector.astro';
   }
   
   .menu-line {
-    width: 18px;
+    width: var(--text-xl);
     height: 2px;
-    background: #1D1D1F;
+    background: var(--color-primary);
     border-radius: 1px;
     transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
     transform-origin: center;
@@ -216,7 +216,7 @@ import LanguageSelector from './LanguageSelector.astro';
   /* Mobile Menu */
   .mobile-menu {
     position: fixed;
-    top: 64px;
+    top: var(--space-16);
     left: 0;
     right: 0;
     bottom: 0;
@@ -235,49 +235,49 @@ import LanguageSelector from './LanguageSelector.astro';
   }
   
   .mobile-menu-content {
-    padding: 60px 40px;
+    padding: var(--space-16) var(--space-10);
     height: 100%;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    gap: 60px;
+    gap: var(--space-16);
   }
   
   .mobile-nav-links {
     display: flex;
     flex-direction: column;
-    gap: 32px;
+    gap: var(--space-8);
     text-align: center;
   }
   
   .mobile-nav-link {
-    font-size: 32px;
+    font-size: var(--text-5xl);
     font-weight: 600;
-    color: #1D1D1F;
+    color: var(--color-primary);
     text-decoration: none;
     transition: all 0.2s ease;
   }
   
   .mobile-nav-link:hover {
-    color: #007AFF;
+    color: var(--color-accent);
     transform: scale(1.05);
   }
   
   .mobile-actions {
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: var(--space-4);
     width: 100%;
     max-width: 280px;
   }
   
   .mobile-cta {
-    background: #1D1D1F;
-    color: #FFFFFF;
-    padding: 16px 32px;
+    background: var(--color-primary);
+    color: var(--color-background);
+    padding: var(--space-4) var(--space-8);
     border-radius: 25px;
-    font-size: 18px;
+    font-size: var(--text-xl);
     font-weight: 600;
     text-decoration: none;
     text-align: center;
@@ -285,23 +285,23 @@ import LanguageSelector from './LanguageSelector.astro';
   }
   
   .mobile-cta:hover {
-    background: #007AFF;
+    background: var(--color-accent);
   }
   
   /* Responsive Design */
   @media (max-width: 1024px) {
     .nav-menu {
-      gap: 32px;
+      gap: var(--space-8);
     }
     
     .nav-actions {
-      gap: 16px;
+      gap: var(--space-4);
     }
   }
   
   @media (max-width: 768px) {
     .nav-container {
-      padding: 0 20px;
+      padding: 0 var(--space-5);
       height: 56px;
     }
     
@@ -319,28 +319,28 @@ import LanguageSelector from './LanguageSelector.astro';
     }
     
     .mobile-menu-content {
-      padding: 40px 20px;
-      gap: 40px;
+      padding: var(--space-10) var(--space-5);
+      gap: var(--space-10);
     }
     
     .mobile-nav-link {
-      font-size: 28px;
+      font-size: var(--text-3xl);
     }
   }
   
   @media (max-width: 480px) {
     .logo-text {
-      font-size: 18px;
+      font-size: var(--text-xl);
     }
     
     .mobile-nav-link {
-      font-size: 24px;
+      font-size: var(--text-2xl);
     }
   }
   
   /* Smooth scroll offset for fixed header */
   html {
-    scroll-padding-top: 64px;
+    scroll-padding-top: var(--space-16);
   }
   
   @media (max-width: 768px) {
@@ -350,109 +350,3 @@ import LanguageSelector from './LanguageSelector.astro';
   }
 </style>
 
-<script>
-  class AppleHeader {
-    constructor() {
-      this.header = document.querySelector('.apple-header');
-      this.mobileMenuBtn = document.getElementById('mobileMenuBtn');
-      this.mobileMenu = document.getElementById('mobileMenu');
-      this.mobileNavLinks = document.querySelectorAll('.mobile-nav-link, .mobile-cta');
-      
-      this.init();
-    }
-    
-    init() {
-      this.setupScrollEffect();
-      this.setupMobileMenu();
-      this.setupSmoothScroll();
-    }
-    
-    setupScrollEffect() {
-      let lastScrollY = window.scrollY;
-      
-      window.addEventListener('scroll', () => {
-        const scrollY = window.scrollY;
-        
-        if (scrollY > 50) {
-          this.header?.classList.add('scrolled');
-        } else {
-          this.header?.classList.remove('scrolled');
-        }
-        
-        lastScrollY = scrollY;
-      });
-    }
-    
-    setupMobileMenu() {
-      this.mobileMenuBtn?.addEventListener('click', () => {
-        this.toggleMobileMenu();
-      });
-      
-      // Close mobile menu when clicking nav links
-      this.mobileNavLinks.forEach(link => {
-        link.addEventListener('click', () => {
-          this.closeMobileMenu();
-        });
-      });
-      
-      // Close mobile menu on escape key
-      document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape') {
-          this.closeMobileMenu();
-        }
-      });
-      
-      // Close mobile menu on outside click
-      this.mobileMenu?.addEventListener('click', (e) => {
-        if (e.target === this.mobileMenu) {
-          this.closeMobileMenu();
-        }
-      });
-    }
-    
-    toggleMobileMenu() {
-      const isActive = this.mobileMenu?.classList.contains('active');
-      if (isActive) {
-        this.closeMobileMenu();
-      } else {
-        this.openMobileMenu();
-      }
-    }
-    
-    openMobileMenu() {
-      this.mobileMenuBtn?.classList.add('active');
-      this.mobileMenu?.classList.add('active');
-      document.body.style.overflow = 'hidden';
-    }
-    
-    closeMobileMenu() {
-      this.mobileMenuBtn?.classList.remove('active');
-      this.mobileMenu?.classList.remove('active');
-      document.body.style.overflow = '';
-    }
-    
-    setupSmoothScroll() {
-      // Smooth scroll for anchor links
-      document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-        anchor.addEventListener('click', function(e) {
-          const href = this.getAttribute('href');
-          if (href === '#') return;
-          
-          const target = document.querySelector(href);
-          if (target) {
-            e.preventDefault();
-            target.scrollIntoView({
-              behavior: 'smooth',
-              block: 'start'
-            });
-          }
-        });
-      });
-    }
-  }
-  
-  // Initialize when DOM is loaded
-  document.addEventListener('DOMContentLoaded', () => {
-    new AppleHeader();
-  });
-</script>

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -193,7 +193,7 @@ import {
     background: 
       linear-gradient(135deg, rgba(0, 102, 204, 0.03) 0%, transparent 50%),
       radial-gradient(circle at 70% 30%, rgba(0, 102, 204, 0.05) 0%, transparent 50%);
-    padding: var(--spacing-5xl) 0;
+    padding: var(--space-24) 0;
   }
   
   .hero-content {
@@ -205,14 +205,14 @@ import {
   /* 品牌标识区域 */
   .company-name {
     font-size: var(--text-5xl);
-    color: var(--text-primary);
+    color: var(--color-primary);
     letter-spacing: 0.02em;
     line-height: 1.2;
   }
   
   .tagline {
     font-size: var(--text-xl);
-    color: var(--text-primary);
+    color: var(--color-primary);
     font-weight: 500;
   }
   
@@ -224,7 +224,7 @@ import {
   /* 主标题 */
   .hero-title {
     font-size: var(--text-4xl);
-    color: var(--text-primary);
+    color: var(--color-primary);
     line-height: 1.3;
     max-width: 800px;
     margin: 0 auto;
@@ -233,7 +233,7 @@ import {
   .hero-subtitle {
     font-size: var(--text-lg);
     line-height: 1.8;
-    color: var(--text-primary);
+    color: var(--color-primary);
     max-width: 900px;
     margin: 0 auto;
     opacity: 0.9;
@@ -247,13 +247,13 @@ import {
   
   .value-card {
     text-align: center;
-    padding: var(--spacing-2xl);
+    padding: var(--space-12);
     border: 1px solid rgba(0, 102, 204, 0.1);
     transition: all 0.3s ease;
   }
   
   .value-card:hover {
-    border-color: var(--accent);
+    border-color: var(--color-accent);
     transform: translateY(-4px);
     box-shadow: 0 8px 24px rgba(0, 102, 204, 0.1);
   }
@@ -262,25 +262,25 @@ import {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--spacing-xs);
+    gap: var(--space-2);
   }
   
   .icon-text {
     width: 60px;
     height: 60px;
-    border: 2px solid var(--accent);
+    border: 2px solid var(--color-accent);
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: var(--text-2xl);
     font-weight: 700;
-    color: var(--accent);
+    color: var(--color-accent);
   }
   
   .value-title {
     font-size: var(--text-xl);
-    color: var(--text-primary);
+    color: var(--color-primary);
   }
   
   .value-description {
@@ -296,24 +296,24 @@ import {
   
   .section-title {
     font-size: var(--text-3xl);
-    color: var(--text-primary);
+    color: var(--color-primary);
   }
   
   .section-subtitle {
     font-size: var(--text-lg);
-    color: var(--text-secondary);
+    color: var(--color-secondary);
   }
   
   .principle-number {
     font-size: var(--text-4xl);
-    color: var(--accent);
+    color: var(--color-accent);
     line-height: 1;
   }
   
   .principle-name {
     font-size: var(--text-lg);
-    color: var(--text-primary);
-    margin-bottom: var(--spacing-sm);
+    color: var(--color-primary);
+    margin-bottom: var(--space-3);
   }
   
   .principle-desc {
@@ -328,15 +328,15 @@ import {
   
   .kpi-value {
     font-size: var(--text-3xl);
-    color: var(--accent);
+    color: var(--color-accent);
     line-height: 1;
-    margin-bottom: var(--spacing-sm);
+    margin-bottom: var(--space-3);
   }
   
   .kpi-label {
     font-size: var(--text-base);
-    color: var(--text-primary);
-    margin-bottom: var(--spacing-xs);
+    color: var(--color-primary);
+    margin-bottom: var(--space-2);
   }
   
   /* 行动按钮 */
@@ -344,8 +344,8 @@ import {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--spacing-xs);
-    padding: var(--spacing-lg) var(--spacing-2xl);
+    gap: var(--space-2);
+    padding: var(--space-6) var(--space-12);
     min-width: 200px;
   }
   
@@ -402,13 +402,13 @@ import {
   @media (max-width: 1200px) {
     .value-propositions {
       grid-template-columns: 1fr;
-      gap: var(--spacing-lg);
+      gap: var(--space-6);
     }
   }
   
   @media (max-width: 768px) {
     .hero-section {
-      padding: var(--spacing-3xl) 0;
+      padding: var(--space-16) 0;
     }
     
     .company-name {
@@ -421,18 +421,18 @@ import {
     
     .principles-grid {
       grid-template-columns: 1fr;
-      gap: var(--spacing-xl);
+      gap: var(--space-8);
     }
     
     .kpi-grid {
       grid-template-columns: repeat(2, 1fr);
-      gap: var(--spacing-lg);
+      gap: var(--space-6);
     }
     
     .cta-buttons {
       flex-direction: column;
       align-items: center;
-      gap: var(--spacing-md);
+      gap: var(--space-4);
     }
     
     .cta-buttons .btn {
@@ -452,7 +452,7 @@ import {
     
     .kpi-grid {
       grid-template-columns: 1fr;
-      gap: var(--spacing-md);
+      gap: var(--space-4);
     }
     
     .kpi-value {

--- a/src/components/LanguageSelector.astro
+++ b/src/components/LanguageSelector.astro
@@ -42,7 +42,7 @@
     border-radius: 20px;
     font-size: 14px;
     font-weight: 500;
-    color: var(--text-primary);
+    color: var(--color-primary);
     cursor: pointer;
     transition: all 0.2s ease;
     backdrop-filter: blur(20px);
@@ -93,7 +93,7 @@
     background: none;
     border: none;
     font-size: 14px;
-    color: var(--text-primary);
+    color: var(--color-primary);
     cursor: pointer;
     transition: background-color 0.2s ease;
   }
@@ -112,7 +112,7 @@
   
   .lang-option.active {
     background: rgba(0, 122, 255, 0.15);
-    color: var(--accent);
+    color: var(--color-accent);
   }
   
   .lang-name {

--- a/src/components/ProductsSection.astro
+++ b/src/components/ProductsSection.astro
@@ -268,42 +268,42 @@
   
   .section-title {
     font-size: var(--text-3xl);
-    color: var(--text-primary);
+    color: var(--color-primary);
   }
   
   .section-subtitle {
     font-size: var(--text-lg);
-    color: var(--text-primary);
+    color: var(--color-primary);
   }
   
   /* 库雷克绿通主打产品 */
   .product-hero {
     background: linear-gradient(135deg, rgba(0, 102, 204, 0.05) 0%, rgba(0, 102, 204, 0.02) 100%);
     border: 2px solid rgba(0, 102, 204, 0.1);
-    padding: var(--spacing-3xl);
+    padding: var(--space-16);
   }
   
   .product-badge {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-sm);
+    gap: var(--space-3);
     background: rgba(0, 102, 204, 0.1);
-    padding: var(--spacing-sm) var(--spacing-lg);
+    padding: var(--space-3) var(--space-6);
     border-radius: 20px;
     font-weight: 500;
-    color: var(--accent);
+    color: var(--color-accent);
   }
   
   .product-title {
     font-size: var(--text-2xl);
-    color: var(--text-primary);
+    color: var(--color-primary);
     line-height: 1.3;
   }
   
   .product-description {
     font-size: var(--text-base);
     line-height: 1.7;
-    color: var(--text-primary);
+    color: var(--color-primary);
     opacity: 0.9;
   }
   
@@ -311,7 +311,7 @@
   .feature-item {
     display: flex;
     align-items: flex-start;
-    gap: var(--spacing-md);
+    gap: var(--space-4);
   }
   
   .feature-icon {
@@ -327,8 +327,8 @@
   }
   
   .feature-content h4 {
-    margin-bottom: var(--spacing-xs);
-    color: var(--text-primary);
+    margin-bottom: var(--space-2);
+    color: var(--color-primary);
   }
   
   /* SLA展示 */
@@ -336,18 +336,18 @@
     background: var(--bg-primary);
     border: 1px solid rgba(0, 102, 204, 0.1);
     border-radius: 12px;
-    padding: var(--spacing-lg);
+    padding: var(--space-6);
   }
   
   .sla-value {
     font-size: var(--text-lg);
-    color: var(--accent);
-    margin-bottom: var(--spacing-xs);
+    color: var(--color-accent);
+    margin-bottom: var(--space-2);
     line-height: 1;
   }
   
   .sla-label {
-    color: var(--text-secondary);
+    color: var(--color-secondary);
   }
   
   /* 路线可视化 */
@@ -356,7 +356,7 @@
     height: 300px;
     background: linear-gradient(135deg, rgba(0, 102, 204, 0.05) 0%, transparent 100%);
     border-radius: 16px;
-    padding: var(--spacing-2xl);
+    padding: var(--space-12);
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -368,7 +368,7 @@
     left: 10%;
     right: 10%;
     height: 3px;
-    background: linear-gradient(90deg, var(--accent) 0%, rgba(0, 102, 204, 0.3) 100%);
+    background: linear-gradient(90deg, var(--color-accent) 0%, rgba(0, 102, 204, 0.3) 100%);
     border-radius: 2px;
     transform: translateY(-50%);
   }
@@ -389,33 +389,33 @@
   .point-dot {
     width: 16px;
     height: 16px;
-    background: var(--accent);
+    background: var(--color-accent);
     border: 3px solid var(--bg-primary);
     border-radius: 50%;
-    margin: 0 auto var(--spacing-sm);
-    box-shadow: 0 0 0 2px var(--accent);
+    margin: 0 auto var(--space-3);
+    box-shadow: 0 0 0 2px var(--color-accent);
   }
   
   .point-label {
     font-weight: 600;
-    color: var(--text-primary);
+    color: var(--color-primary);
     font-size: var(--text-sm);
   }
   
   .route-info {
-    margin-top: var(--spacing-xl);
+    margin-top: var(--space-8);
     text-align: center;
   }
   
   /* 产品卡片 */
   .product-card {
-    padding: var(--spacing-2xl);
+    padding: var(--space-12);
     border: 1px solid rgba(0, 102, 204, 0.1);
     transition: all 0.3s ease;
   }
   
   .product-card:hover {
-    border-color: var(--accent);
+    border-color: var(--color-accent);
     transform: translateY(-4px);
     box-shadow: 0 8px 24px rgba(0, 102, 204, 0.1);
   }
@@ -423,7 +423,7 @@
   .product-header {
     display: flex;
     align-items: center;
-    gap: var(--spacing-md);
+    gap: var(--space-4);
   }
   
   .product-icon {
@@ -440,26 +440,26 @@
   
   .product-name {
     font-size: var(--text-lg);
-    color: var(--text-primary);
-    margin-bottom: var(--spacing-xs);
+    color: var(--color-primary);
+    margin-bottom: var(--space-2);
   }
   
   .product-desc {
     line-height: 1.6;
-    margin-bottom: var(--spacing-lg);
+    margin-bottom: var(--space-6);
   }
   
   /* 标签 */
   .product-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--spacing-sm);
+    gap: var(--space-3);
   }
   
   .tag {
     background: rgba(0, 102, 204, 0.1);
-    color: var(--accent);
-    padding: var(--spacing-xs) var(--spacing-sm);
+    color: var(--color-accent);
+    padding: var(--space-2) var(--space-3);
     border-radius: 16px;
     font-size: var(--text-xs);
     font-weight: 500;
@@ -469,7 +469,7 @@
   .financial-services {
     background: rgba(0, 102, 204, 0.03);
     border-radius: 16px;
-    padding: var(--spacing-3xl) var(--spacing-2xl);
+    padding: var(--space-16) var(--space-12);
   }
   
   .financial-icon {
@@ -477,23 +477,23 @@
   }
   
   .financial-item h4 {
-    color: var(--text-primary);
-    margin-bottom: var(--spacing-sm);
+    color: var(--color-primary);
+    margin-bottom: var(--space-3);
   }
   
   /* 行动区域 */
   .action-section {
     background: linear-gradient(135deg, rgba(0, 102, 204, 0.05) 0%, rgba(0, 102, 204, 0.02) 100%);
     border-radius: 16px;
-    padding: var(--spacing-3xl) var(--spacing-2xl);
+    padding: var(--space-16) var(--space-12);
   }
   
   .action-buttons .btn {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--spacing-xs);
-    padding: var(--spacing-lg) var(--spacing-2xl);
+    gap: var(--space-2);
+    padding: var(--space-6) var(--space-12);
     min-width: 200px;
   }
   
@@ -501,7 +501,7 @@
   @media (max-width: 1200px) {
     .product-content {
       grid-template-columns: 1fr;
-      gap: var(--spacing-3xl);
+      gap: var(--space-16);
     }
     
     .product-visual {
@@ -512,23 +512,23 @@
   @media (max-width: 768px) {
     .products-list {
       grid-template-columns: 1fr;
-      gap: var(--spacing-lg);
+      gap: var(--space-6);
     }
     
     .sla-grid {
       grid-template-columns: 1fr;
-      gap: var(--spacing-sm);
+      gap: var(--space-3);
     }
     
     .financial-grid {
       grid-template-columns: 1fr;
-      gap: var(--spacing-lg);
+      gap: var(--space-6);
     }
     
     .action-buttons {
       flex-direction: column;
       align-items: center;
-      gap: var(--spacing-md);
+      gap: var(--space-4);
     }
     
     .action-buttons .btn {
@@ -539,12 +539,12 @@
   
   @media (max-width: 480px) {
     .product-hero {
-      padding: var(--spacing-2xl) var(--spacing-lg);
+      padding: var(--space-12) var(--space-6);
     }
     
     .route-map {
       height: 200px;
-      padding: var(--spacing-lg);
+      padding: var(--space-6);
     }
     
     .point-label {

--- a/src/components/ServicesSection.astro
+++ b/src/components/ServicesSection.astro
@@ -126,12 +126,12 @@
   }
   
   .section-number {
-    margin-bottom: var(--spacing-xl);
+    margin-bottom: var(--space-8);
   }
   
   .section-number .accent-number {
     display: block;
-    margin-bottom: var(--spacing-sm);
+    margin-bottom: var(--space-3);
   }
   
   .section-description {
@@ -141,7 +141,7 @@
   }
   
   .services-grid {
-    margin-bottom: var(--spacing-4xl);
+    margin-bottom: var(--space-20);
   }
   
   .service-card {
@@ -152,64 +152,64 @@
   }
   
   .service-card:hover {
-    border-color: var(--accent-primary);
+    border-color: var(--color-accent);
     transform: translateY(-8px);
   }
   
   .service-icon {
-    margin-bottom: var(--spacing-xl);
+    margin-bottom: var(--space-8);
     position: relative;
   }
   
   .service-icon .large-element {
     display: block;
-    color: var(--accent-primary);
-    margin-bottom: var(--spacing-sm);
+    color: var(--color-accent);
+    margin-bottom: var(--space-3);
     text-shadow: 0 2px 10px rgba(87, 81, 213, 0.2);
   }
   
   .service-title {
-    color: var(--text-primary);
-    margin-bottom: var(--spacing-md);
+    color: var(--color-primary);
+    margin-bottom: var(--space-4);
   }
   
   .service-description {
     line-height: 1.8;
-    color: var(--text-primary);
-    margin-bottom: var(--spacing-xl);
+    color: var(--color-primary);
+    margin-bottom: var(--space-8);
   }
   
   .service-features {
     text-align: left;
-    padding-left: var(--spacing-lg);
+    padding-left: var(--space-6);
   }
   
   .service-features .feature {
-    margin-bottom: var(--spacing-xs);
+    margin-bottom: var(--space-2);
     line-height: 1.6;
   }
   
   /* 核心价值观样式 */
   .values-section {
-    padding-top: var(--spacing-4xl);
+    padding-top: var(--space-20);
     border-top: 1px solid rgba(22, 22, 21, 0.1);
   }
   
   .value-item {
-    padding: var(--spacing-lg);
+    padding: var(--space-6);
   }
   
   .value-number {
     font-size: var(--text-6xl);
     line-height: 1;
-    margin-bottom: var(--spacing-md);
+    margin-bottom: var(--space-4);
     opacity: 0.8;
   }
   
   .value-text {
     font-size: var(--text-xl);
-    margin-bottom: var(--spacing-xs);
-    color: var(--text-primary);
+    margin-bottom: var(--space-2);
+    color: var(--color-primary);
   }
   
   .value-subtitle {
@@ -220,19 +220,19 @@
   /* 响应式设计 */
   @media (max-width: 1200px) {
     .services-grid {
-      gap: var(--spacing-lg);
+      gap: var(--space-6);
     }
   }
   
   @media (max-width: 768px) {
     .services-grid {
       grid-template-columns: 1fr;
-      gap: var(--spacing-xl);
+      gap: var(--space-8);
     }
     
     .values-grid {
       grid-template-columns: repeat(2, 1fr);
-      gap: var(--spacing-xl);
+      gap: var(--space-8);
     }
     
     .service-features {
@@ -244,7 +244,7 @@
   @media (max-width: 480px) {
     .values-grid {
       grid-template-columns: 1fr;
-      gap: var(--spacing-lg);
+      gap: var(--space-6);
     }
     
     .value-number {

--- a/src/components/SolutionsSection.astro
+++ b/src/components/SolutionsSection.astro
@@ -357,68 +357,68 @@
   
   .section-title {
     font-size: var(--text-3xl);
-    color: var(--text-primary);
+    color: var(--color-primary);
   }
   
   .section-subtitle {
     font-size: var(--text-lg);
-    color: var(--text-primary);
+    color: var(--color-primary);
   }
   
   /* 特色解决方案 */
   .solution-featured {
     background: linear-gradient(135deg, rgba(0, 102, 204, 0.05) 0%, rgba(0, 102, 204, 0.02) 100%);
     border: 2px solid rgba(0, 102, 204, 0.1);
-    padding: var(--spacing-3xl);
+    padding: var(--space-16);
   }
   
   .solution-category {
     display: inline-flex;
     align-items: center;
-    gap: var(--spacing-sm);
+    gap: var(--space-3);
     background: rgba(0, 102, 204, 0.1);
-    padding: var(--spacing-sm) var(--spacing-lg);
+    padding: var(--space-3) var(--space-6);
     border-radius: 20px;
     font-weight: 500;
-    color: var(--accent);
+    color: var(--color-accent);
   }
   
   .solution-title {
     font-size: var(--text-2xl);
-    color: var(--text-primary);
+    color: var(--color-primary);
     line-height: 1.3;
   }
   
   .solution-description {
     font-size: var(--text-base);
     line-height: 1.7;
-    color: var(--text-primary);
+    color: var(--color-primary);
     opacity: 0.9;
   }
   
   /* 特性列表 */
   .feature-title {
-    color: var(--text-primary);
-    margin-bottom: var(--spacing-md);
+    color: var(--color-primary);
+    margin-bottom: var(--space-4);
   }
   
   .features-list {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-sm);
+    gap: var(--space-3);
   }
   
   .feature-item {
     display: flex;
     align-items: center;
-    gap: var(--spacing-sm);
+    gap: var(--space-3);
     font-size: var(--text-sm);
   }
   
   .feature-dot {
     width: 6px;
     height: 6px;
-    background: var(--accent);
+    background: var(--color-accent);
     border-radius: 50%;
     flex-shrink: 0;
   }
@@ -428,7 +428,7 @@
     background: var(--bg-primary);
     border: 1px solid rgba(0, 102, 204, 0.1);
     border-radius: 12px;
-    padding: var(--spacing-lg);
+    padding: var(--space-6);
   }
   
   .metric-item {
@@ -437,27 +437,27 @@
   
   .metric-value {
     font-size: var(--text-lg);
-    color: var(--accent);
-    margin-bottom: var(--spacing-xs);
+    color: var(--color-accent);
+    margin-bottom: var(--space-2);
     line-height: 1;
   }
   
   .metric-label {
-    color: var(--text-secondary);
+    color: var(--color-secondary);
   }
   
   /* 流程可视化 */
   .process-flow {
     background: linear-gradient(135deg, rgba(0, 102, 204, 0.05) 0%, transparent 100%);
     border-radius: 16px;
-    padding: var(--spacing-2xl);
+    padding: var(--space-12);
   }
   
   .flow-steps {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: var(--spacing-lg);
+    margin-bottom: var(--space-6);
   }
   
   .step {
@@ -469,37 +469,37 @@
     width: 48px;
     height: 48px;
     background: var(--bg-primary);
-    border: 2px solid var(--accent);
+    border: 2px solid var(--color-accent);
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: var(--text-lg);
-    margin: 0 auto var(--spacing-sm);
+    margin: 0 auto var(--space-3);
   }
   
   .step-label {
     font-weight: 600;
-    color: var(--text-primary);
+    color: var(--color-primary);
     font-size: var(--text-sm);
   }
   
   .flow-arrow {
-    color: var(--accent);
+    color: var(--color-accent);
     font-size: var(--text-xl);
     font-weight: bold;
-    margin: 0 var(--spacing-md);
+    margin: 0 var(--space-4);
   }
   
   /* 解决方案卡片 */
   .solution-card {
-    padding: var(--spacing-2xl);
+    padding: var(--space-12);
     border: 1px solid rgba(0, 102, 204, 0.1);
     transition: all 0.3s ease;
   }
   
   .solution-card:hover {
-    border-color: var(--accent);
+    border-color: var(--color-accent);
     transform: translateY(-4px);
     box-shadow: 0 8px 24px rgba(0, 102, 204, 0.1);
   }
@@ -507,7 +507,7 @@
   .solution-header {
     display: flex;
     align-items: center;
-    gap: var(--spacing-md);
+    gap: var(--space-4);
   }
   
   .solution-icon {
@@ -524,32 +524,32 @@
   
   .solution-name {
     font-size: var(--text-lg);
-    color: var(--text-primary);
-    margin-bottom: var(--spacing-xs);
+    color: var(--color-primary);
+    margin-bottom: var(--space-2);
   }
   
   .solution-desc {
     line-height: 1.6;
-    margin-bottom: var(--spacing-lg);
+    margin-bottom: var(--space-6);
   }
   
   /* 亮点展示 */
   .solution-highlights {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-sm);
+    gap: var(--space-3);
   }
   
   .highlight-item {
     display: flex;
     align-items: center;
-    gap: var(--spacing-sm);
+    gap: var(--space-3);
   }
   
   .highlight-dot {
     width: 4px;
     height: 4px;
-    background: var(--accent);
+    background: var(--color-accent);
     border-radius: 50%;
     flex-shrink: 0;
   }
@@ -558,7 +558,7 @@
   .solution-stats {
     background: rgba(0, 102, 204, 0.05);
     border-radius: 8px;
-    padding: var(--spacing-md);
+    padding: var(--space-4);
     text-align: center;
   }
   
@@ -569,32 +569,32 @@
   }
   
   .stat-value {
-    color: var(--accent);
+    color: var(--color-accent);
   }
   
   /* 成功案例 */
   .case-studies {
     background: rgba(0, 102, 204, 0.03);
     border-radius: 16px;
-    padding: var(--spacing-3xl) var(--spacing-2xl);
+    padding: var(--space-16) var(--space-12);
   }
   
   .case-item {
-    padding: var(--spacing-xl);
+    padding: var(--space-8);
     border: 1px solid rgba(0, 102, 204, 0.1);
   }
   
   .case-category {
-    color: var(--accent);
+    color: var(--color-accent);
     background: rgba(0, 102, 204, 0.1);
-    padding: var(--spacing-xs) var(--spacing-sm);
+    padding: var(--space-2) var(--space-3);
     border-radius: 12px;
     font-size: var(--text-xs);
     display: inline-block;
   }
   
   .case-title {
-    color: var(--text-primary);
+    color: var(--color-primary);
     font-size: var(--text-lg);
   }
   
@@ -609,22 +609,22 @@
   }
   
   .result-value {
-    color: var(--accent);
+    color: var(--color-accent);
   }
   
   /* 咨询CTA */
   .consultation-cta {
     background: linear-gradient(135deg, rgba(0, 102, 204, 0.05) 0%, rgba(0, 102, 204, 0.02) 100%);
     border-radius: 16px;
-    padding: var(--spacing-3xl) var(--spacing-2xl);
+    padding: var(--space-16) var(--space-12);
   }
   
   .cta-buttons .btn {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--spacing-xs);
-    padding: var(--spacing-lg) var(--spacing-2xl);
+    gap: var(--space-2);
+    padding: var(--space-6) var(--space-12);
     min-width: 200px;
   }
   
@@ -632,7 +632,7 @@
   @media (max-width: 1200px) {
     .solution-content {
       grid-template-columns: 1fr;
-      gap: var(--spacing-3xl);
+      gap: var(--space-16);
     }
     
     .solution-visual {
@@ -643,17 +643,17 @@
   @media (max-width: 768px) {
     .solutions-list {
       grid-template-columns: 1fr;
-      gap: var(--spacing-lg);
+      gap: var(--space-6);
     }
     
     .cases-grid {
       grid-template-columns: 1fr;
-      gap: var(--spacing-lg);
+      gap: var(--space-6);
     }
     
     .flow-steps {
       flex-direction: column;
-      gap: var(--spacing-lg);
+      gap: var(--space-6);
     }
     
     .flow-arrow {
@@ -664,7 +664,7 @@
     .cta-buttons {
       flex-direction: column;
       align-items: center;
-      gap: var(--spacing-md);
+      gap: var(--space-4);
     }
     
     .cta-buttons .btn {
@@ -675,11 +675,11 @@
   
   @media (max-width: 480px) {
     .solution-featured {
-      padding: var(--spacing-2xl) var(--spacing-lg);
+      padding: var(--space-12) var(--space-6);
     }
     
     .metric-item {
-      margin-bottom: var(--spacing-md);
+      margin-bottom: var(--space-4);
     }
   }
 </style>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -59,7 +59,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 		<main>
 			<article>
 				<div class="hero-image">
-					{heroImage && <img width={1020} height={510} src={heroImage} alt="" />}
+					{heroImage && <img width={1020} height={510} src={heroImage} alt={title} />}
 				</div>
 				<div class="prose">
 					<div class="title">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,4 +1,5 @@
 ---
+import '../scripts/main.ts';
 import Layout from '../layouts/BlogPost.astro';
 ---
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,4 +1,5 @@
 ---
+import '../../scripts/main.ts';
 import { type CollectionEntry, getCollection } from 'astro:content';
 import BlogPost from '../../layouts/BlogPost.astro';
 import { render } from 'astro:content';

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseHead from '../../components/BaseHead.astro';
+import '../../scripts/main.ts';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
@@ -63,7 +64,7 @@ const posts = (await getCollection('blog')).sort(
 			}
 			ul li a:hover h4,
 			ul li a:hover .date {
-				color: rgb(var(--accent));
+				color: rgb(var(--color-accent));
 			}
 			ul a:hover img {
 				box-shadow: var(--box-shadow);
@@ -94,7 +95,7 @@ const posts = (await getCollection('blog')).sort(
 						posts.map((post) => (
 							<li>
 								<a href={`/blog/${post.id}/`}>
-									<img width={720} height={360} src={post.data.heroImage} alt="" />
+									<img width={720} height={360} src={post.data.heroImage} alt={post.data.title} />
 									<h4 class="title">{post.data.title}</h4>
 									<p class="date">
 										<FormattedDate date={post.data.pubDate} />

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,5 +1,6 @@
 ---
 import BaseHead from '../components/BaseHead.astro';
+import '../scripts/main.ts';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import ContactSection from '../components/ContactSection.astro';

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseHead from '../components/BaseHead.astro';
+import '../scripts/main.ts';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import AppleHeroSection from '../components/AppleHeroSection.astro';
@@ -110,7 +111,7 @@ import { SITE_TITLE, SITE_DESCRIPTION, TRANSLATIONS, TRACKING_DATA, CUSTOMER_REV
 			
 			/* 选择文本样式 */
 			::selection {
-				background-color: var(--accent-primary);
+				background-color: var(--color-accent);
 				color: var(--bg-primary);
 			}
 			
@@ -163,9 +164,9 @@ import { SITE_TITLE, SITE_DESCRIPTION, TRANSLATIONS, TRACKING_DATA, CUSTOMER_REV
 			@media (prefers-contrast: high) {
 				:root {
 					--bg-primary: #ffffff;
-					--text-primary: #000000;
-					--accent-primary: #0000ff;
-					--text-secondary: #333333;
+					--color-primary: #000000;
+					--color-accent: #0000ff;
+					--color-secondary: #333333;
 				}
 			}
 			
@@ -189,7 +190,7 @@ import { SITE_TITLE, SITE_DESCRIPTION, TRANSLATIONS, TRACKING_DATA, CUSTOMER_REV
 			.form-input:focus-visible,
 			.form-select:focus-visible,
 			.form-textarea:focus-visible {
-				outline: 2px solid var(--accent-primary);
+				outline: 2px solid var(--color-accent);
 				outline-offset: 2px;
 			}
 			

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -1,5 +1,6 @@
 ---
 import BaseHead from '../components/BaseHead.astro';
+import '../scripts/main.ts';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import ServicesSection from '../components/ServicesSection.astro';

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -1,0 +1,84 @@
+class AppHeader {
+  header: HTMLElement | null;
+  mobileMenuBtn: HTMLButtonElement | null;
+  mobileMenu: HTMLElement | null;
+  mobileNavLinks: NodeListOf<HTMLAnchorElement>;
+
+  constructor() {
+    this.header = document.querySelector('.apple-header');
+    this.mobileMenuBtn = document.getElementById('mobileMenuBtn') as HTMLButtonElement;
+    this.mobileMenu = document.getElementById('mobileMenu');
+    this.mobileNavLinks = this.mobileMenu?.querySelectorAll('a') ?? document.querySelectorAll('');
+
+    this.init();
+  }
+
+  init() {
+    this.setupScrollEffect();
+    this.setupMobileMenu();
+    this.setupSmoothScroll();
+  }
+
+  setupScrollEffect() {
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 50) {
+        this.header?.classList.add('scrolled');
+      } else {
+        this.header?.classList.remove('scrolled');
+      }
+    });
+  }
+
+  setupMobileMenu() {
+    this.mobileMenuBtn?.addEventListener('click', () => this.toggleMobileMenu());
+
+    // close on escape
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && this.mobileMenuBtn?.getAttribute('aria-expanded') === 'true') {
+        this.toggleMobileMenu();
+      }
+    });
+
+    // close when clicking link
+    this.mobileNavLinks.forEach(link => {
+      link.addEventListener('click', () => {
+        if (this.mobileMenuBtn?.getAttribute('aria-expanded') === 'true') {
+          this.toggleMobileMenu();
+        }
+      });
+    });
+  }
+
+  toggleMobileMenu() {
+    const expanded = this.mobileMenuBtn?.getAttribute('aria-expanded') === 'true';
+    this.mobileMenuBtn?.setAttribute('aria-expanded', String(!expanded));
+    this.mobileMenu?.classList.toggle('active');
+    document.body.style.overflow = expanded ? '' : 'hidden';
+    if (!expanded) {
+      // focus first link
+      (this.mobileNavLinks[0] as HTMLElement)?.focus();
+    } else {
+      this.mobileMenuBtn?.focus();
+    }
+  }
+
+  setupSmoothScroll() {
+    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+      anchor.addEventListener('click', (e) => {
+        const href = (anchor as HTMLAnchorElement).getAttribute('href');
+        if (!href || href === '#') return;
+        const target = document.querySelector(href);
+        if (target) {
+          e.preventDefault();
+          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      });
+    });
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', () => {
+    new AppHeader();
+  });
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,77 +8,8 @@
 @import url('https://fonts.googleapis.com/css2?family=SF+Pro+Text:wght@100;200;300;400;500;600;700;800;900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@100;200;300;400;500;600;700;800;900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans:wght@100;200;300;400;500;600;700;800;900&display=swap');
+@import "./tokens.css";
 
-:root {
-  /* Apple Color System */
-  --color-primary: #1D1D1F;
-  --color-secondary: #86868B;
-  --color-tertiary: #F5F5F7;
-  --color-background: #FFFFFF;
-  --color-surface: #F5F5F7;
-  --color-accent: #007AFF;
-  --color-accent-hover: #0056CC;
-  --color-success: #34C759;
-  --color-warning: #FF9500;
-  --color-error: #FF3B30;
-  --color-border: #E5E5E7;
-  
-  /* Typography Scale - Apple Style */
-  --text-xs: 11px;
-  --text-sm: 12px;
-  --text-base: 14px;
-  --text-lg: 16px;
-  --text-xl: 18px;
-  --text-2xl: 20px;
-  --text-3xl: 24px;
-  --text-4xl: 28px;
-  --text-5xl: 32px;
-  --text-6xl: 40px;
-  --text-7xl: 48px;
-  --text-8xl: 64px;
-  --text-9xl: 80px;
-  --text-10xl: 96px;
-  --text-11xl: 128px;
-  
-  /* Spacing System */
-  --space-1: 4px;
-  --space-2: 8px;
-  --space-3: 12px;
-  --space-4: 16px;
-  --space-5: 20px;
-  --space-6: 24px;
-  --space-8: 32px;
-  --space-10: 40px;
-  --space-12: 48px;
-  --space-16: 64px;
-  --space-20: 80px;
-  --space-24: 96px;
-  --space-32: 128px;
-  --space-40: 160px;
-  --space-48: 192px;
-  --space-64: 256px;
-  
-  /* Border Radius */
-  --radius-sm: 6px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
-  --radius-xl: 16px;
-  --radius-2xl: 20px;
-  --radius-3xl: 24px;
-  --radius-full: 9999px;
-  
-  /* Shadows - Apple Style */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.05);
-  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
-  --shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.1);
-  --shadow-2xl: 0 25px 50px rgba(0, 0, 0, 0.15);
-  
-  /* Animation Curves - Apple Bezier */
-  --ease-out: cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  --ease-in-out: cubic-bezier(0.25, 0.1, 0.25, 1);
-  --ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
-}
 
 /* Reset and Base Styles */
 * {
@@ -102,7 +33,7 @@ html {
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Noto Sans SC', 'Noto Sans', system-ui, sans-serif;
+  font-family: var(--font-sans);
   font-size: var(--text-lg);
   line-height: 1.5;
   color: var(--color-primary);
@@ -113,25 +44,25 @@ body {
 
 /* Typography System */
 .sf-pro-display {
-  font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  font-family: var(--font-display);
 }
 
 .sf-pro-text {
-  font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  font-family: var(--font-sans);
 }
 
 .chinese-text {
-  font-family: 'SF Pro Text', 'Noto Sans SC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  font-family: var(--font-sans);
   font-weight: 500;
 }
 
 .english-text {
-  font-family: 'SF Pro Text', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  font-family: var(--font-sans);
 }
 
 /* Headings */
 h1, h2, h3, h4, h5, h6 {
-  font-family: 'SF Pro Display', 'Noto Sans SC', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  font-family: var(--font-display);
   font-weight: 700;
   line-height: 1.2;
   color: var(--color-primary);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,83 @@
+:root {
+  /* Color System */
+  --color-primary: #1D1D1F;
+  --color-secondary: #86868B;
+  --color-tertiary: #F5F5F7;
+  --color-background: #FFFFFF;
+  --color-surface: #F5F5F7;
+  --color-accent: #007AFF;
+  --color-accent-hover: #0056CC;
+  --color-accent-secondary: #00D4FF;
+  --color-success: #34C759;
+  --color-warning: #FF9500;
+  --color-error: #FF3B30;
+  --color-border: #E5E5E7;
+  --text-primary: var(--color-primary);
+  --text-secondary: var(--color-secondary);
+
+  /* Font Families */
+  --font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Noto Sans SC', 'Noto Sans', system-ui, sans-serif;
+  --font-display: 'SF Pro Display', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+
+  /* Typography Scale */
+  --text-xs: 11px;
+  --text-sm: 12px;
+  --text-base: 14px;
+  --text-lg: 16px;
+  --text-xl: 18px;
+  --text-2xl: 20px;
+  --text-3xl: 24px;
+  --text-4xl: 28px;
+  --text-5xl: 32px;
+  --text-6xl: 40px;
+  --text-7xl: 48px;
+  --text-8xl: 64px;
+  --text-9xl: 80px;
+  --text-10xl: 96px;
+  --text-11xl: 128px;
+
+  /* Spacing System */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+  --space-20: 80px;
+  --space-24: 96px;
+  --space-32: 128px;
+  --space-40: 160px;
+  --space-48: 192px;
+  --space-64: 256px;
+
+  /* Border Radius */
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-2xl: 20px;
+  --radius-3xl: 24px;
+  --radius-full: 9999px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.05);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
+  --shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.1);
+  --shadow-2xl: 0 25px 50px rgba(0, 0, 0, 0.15);
+
+  /* Animation Curves */
+  --ease-out: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  --ease-in-out: cubic-bezier(0.25, 0.1, 0.25, 1);
+  --ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+
+  /* Breakpoints */
+  --bp-sm: 480px;
+  --bp-md: 768px;
+  --bp-lg: 1024px;
+  --bp-xl: 1280px;
+}


### PR DESCRIPTION
## Summary
- expand tokens with font families, color aliases and breakpoints
- replace legacy spacing/color variables across components to use design tokens
- centralize header behavior in `src/scripts/main.ts` and load globally with accessible mobile menu

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aace61c3b083209c0f4e65cc4d7e86